### PR TITLE
Add opt-in concurrent evaluation (overlap eval with next solve)

### DIFF
--- a/src/slop_code/agent_runner/models.py
+++ b/src/slop_code/agent_runner/models.py
@@ -170,6 +170,18 @@ class AgentRunSpec(BaseModel):
             description="Whether to skip evaluation and force all checkpoints to run."
         ),
     ] = False
+    concurrent_evaluation: Annotated[
+        bool,
+        Field(
+            description="Evaluate each checkpoint concurrently with the next "
+            "checkpoint's solve, instead of serially between checkpoints, so "
+            "eval no longer blocks progress. At most one solve and one eval "
+            "run at a time. Eval results never feed the agent, so scores are "
+            "unchanged for the ANY_CASE pass policy. Trade-off: cannot "
+            "early-stop on test failures (a checkpoint's eval finishes during "
+            "the next solve); agent errors and rate limits still stop the run."
+        ),
+    ] = False
     verbose: Annotated[
         bool, Field(description="Whether to print verbose output")
     ] = False

--- a/src/slop_code/agent_runner/runner.py
+++ b/src/slop_code/agent_runner/runner.py
@@ -474,6 +474,9 @@ class AgentRunner:
         # Guards record_checkpoint_result against the background eval thread.
         self._metrics_lock = threading.Lock()
         self._eval_reports: dict[str, CorrectnessResults] = {}
+        # Checkpoints whose concurrent eval raised. Surfaced at each cp boundary
+        # in _run_problem so failures don't stay hidden until end-of-run.
+        self._failed_evals: dict[str, str] = {}
 
     @property
     def session(self) -> Session:
@@ -947,12 +950,14 @@ class AgentRunner:
                 problem=self.run_spec.problem,
                 environment=self.run_spec.environment,
             )
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             logger.error(
                 "Concurrent evaluation failed",
                 checkpoint=checkpoint.name,
                 exc_info=True,
             )
+            with self._metrics_lock:
+                self._failed_evals[checkpoint.name] = repr(exc)
             return
         with self._metrics_lock:
             self._eval_reports[checkpoint.name] = report
@@ -1007,6 +1012,8 @@ class AgentRunner:
         results = []
         # Rolling background eval thread; previous joined before next starts.
         pending_eval: threading.Thread | None = None
+        # Failed evals already surfaced; tracked to avoid re-logging.
+        reported_fails: set[str] = set()
         for idx, (checkpoint, checkpoint_save_dir) in enumerate(
             get_checkpoints(self.run_spec.problem, self.output_path)
         ):
@@ -1033,6 +1040,20 @@ class AgentRunner:
                     )
                 continue
 
+            # Surface any concurrent-eval failures that completed since the
+            # last cp boundary so a broken eval is visible at the next
+            # iteration, not silently absent until end-of-run.
+            with self._metrics_lock:
+                new_fails = set(self._failed_evals) - reported_fails
+            for cp_name in new_fails:
+                logger.warning(
+                    "Concurrent eval failed for earlier checkpoint "
+                    "(run continues; final report will show missing eval)",
+                    checkpoint=cp_name,
+                    error=self._failed_evals[cp_name],
+                )
+            reported_fails.update(new_fails)
+
             logger.info(
                 "Running checkpoint",
                 checkpoint=checkpoint.name,
@@ -1043,11 +1064,20 @@ class AgentRunner:
             self.metrics_tracker.current_checkpoint = checkpoint.name
             self.metrics_tracker.checkpoint_started = datetime.now()
 
-            summary = self._run_checkpoint(
-                checkpoint,
-                checkpoint_save_dir,
-                idx == 0,
-            )
+            try:
+                summary = self._run_checkpoint(
+                    checkpoint,
+                    checkpoint_save_dir,
+                    idx == 0,
+                )
+            except BaseException:
+                # Solve raised — make sure any in-flight eval container is
+                # joined before the exception propagates, so its session
+                # cleanup runs. Daemon threads don't run finally on process
+                # shutdown, which would otherwise strand a docker container.
+                if pending_eval is not None:
+                    pending_eval.join()
+                raise
             results.append(summary)
             self.metrics_tracker.finish_checkpoint(self.agent.usage)
 
@@ -1087,6 +1117,16 @@ class AgentRunner:
         if pending_eval is not None:
             pending_eval.join()
         results = self._merge_eval_reports(results)
+
+        # End-of-run summary of any concurrent-eval failures. They've already
+        # been logged at the cp boundary, but a single summary line at the
+        # end makes them easy to grep from chain logs.
+        if self._failed_evals:
+            logger.warning(
+                "Run completed with concurrent eval failures",
+                failed_checkpoints=sorted(self._failed_evals.keys()),
+                count=len(self._failed_evals),
+            )
 
         logger.info(
             "All checkpoints completed successfully",

--- a/src/slop_code/agent_runner/runner.py
+++ b/src/slop_code/agent_runner/runner.py
@@ -688,8 +688,7 @@ class AgentRunner:
             summary.passed_policy is not None and not summary.passed_policy
         )
         if self.run_spec.skip_evaluation or self.run_spec.concurrent_evaluation:
-            # No inline eval results to gate on (eval runs concurrently with
-            # the next solve); agent errors / rate limits below still stop it.
+            # No inline eval results to gate on; agent errors below still stop the run.
             did_fail_tests = False
         if did_fail_tests and self.run_spec.pass_policy != PassPolicy.ANY_CASE:
             logger.info(
@@ -789,10 +788,7 @@ class AgentRunner:
                 or self.run_spec.concurrent_evaluation
                 or result is None
             ):
-                # Skip inline evaluation. For concurrent_evaluation a background
-                # thread evaluates the snapshot concurrently with the next
-                # solve (see _run_problem / _eval_one); record None now for
-                # progress and let the eval thread overwrite it.
+                # Skip inline eval; concurrent mode's bg thread overwrites later.
                 with self._metrics_lock:
                     self.metrics_tracker.record_checkpoint_result(
                         checkpoint.name, None
@@ -937,13 +933,11 @@ class AgentRunner:
         checkpoint: CheckpointConfig,
         summary: AgentCheckpointSummary,
     ) -> None:
-        """Evaluate one solved snapshot (concurrent mode; runs in a thread).
+        """Evaluate one solved snapshot in a background thread (concurrent mode).
 
-        Spawns its own eval container; the snapshot is an immutable per-
-        checkpoint copy, so this is safe to run concurrently with the next
-        checkpoint's solve. At most one of these runs at a time (the caller
-        joins the previous one first), so solve stays <=1 checkpoint ahead of
-        eval and in-flight containers are bounded to 2 (this eval + 1 solve).
+        Snapshot is an immutable per-cp copy, so safe to run alongside the next
+        solve. Caller joins the previous thread first, bounding in-flight
+        containers to 2 (1 solve + 1 eval).
         """
         try:
             report, _ = evaluate_agent_snapshot(
@@ -1011,9 +1005,7 @@ class AgentRunner:
         )
 
         results = []
-        # Concurrent mode: a single rolling background eval thread. The previous
-        # one is joined before the next starts, so solve stays <=1 checkpoint
-        # ahead of eval and at most 2 containers (1 solve + 1 eval) run at once.
+        # Rolling background eval thread; previous joined before next starts.
         pending_eval: threading.Thread | None = None
         for idx, (checkpoint, checkpoint_save_dir) in enumerate(
             get_checkpoints(self.run_spec.problem, self.output_path)
@@ -1068,9 +1060,8 @@ class AgentRunner:
                 checkpoint_name=summary.checkpoint_name,
             )
 
-            # Concurrent mode: evaluate this checkpoint in the background while
-            # the next one solves. Join the previous eval first (backpressure:
-            # solve stays <=1 ahead, bounding in-flight containers to 2).
+            # Spawn this cp's eval in the bg; join prior one first (bounds
+            # in-flight containers to 2).
             if (
                 self.run_spec.concurrent_evaluation
                 and not summary.had_error
@@ -1092,8 +1083,7 @@ class AgentRunner:
                     pending_eval.join()
                 return self._merge_eval_reports(results)
 
-        # Concurrent eval: wait for the final background eval, then fold all
-        # reports into the summaries (no-op when concurrent eval is off).
+        # Wait for the final bg eval and fold reports (no-op when off).
         if pending_eval is not None:
             pending_eval.join()
         results = self._merge_eval_reports(results)

--- a/src/slop_code/agent_runner/runner.py
+++ b/src/slop_code/agent_runner/runner.py
@@ -470,6 +470,10 @@ class AgentRunner:
         )
         self.progress_thread: threading.Thread | None = None
         self.results: list[AgentCheckpointSummary] = []
+        # Concurrent-eval bookkeeping (eval overlaps the next solve).
+        # Guards record_checkpoint_result against the background eval thread.
+        self._metrics_lock = threading.Lock()
+        self._eval_reports: dict[str, CorrectnessResults] = {}
 
     @property
     def session(self) -> Session:
@@ -683,7 +687,9 @@ class AgentRunner:
         did_fail_tests = (
             summary.passed_policy is not None and not summary.passed_policy
         )
-        if self.run_spec.skip_evaluation:
+        if self.run_spec.skip_evaluation or self.run_spec.concurrent_evaluation:
+            # No inline eval results to gate on (eval runs concurrently with
+            # the next solve); agent errors / rate limits below still stop it.
             did_fail_tests = False
         if did_fail_tests and self.run_spec.pass_policy != PassPolicy.ANY_CASE:
             logger.info(
@@ -778,11 +784,19 @@ class AgentRunner:
                 )
                 self.metrics_tracker.state = AgentStateEnum.HIT_RATE_LIMITED
                 rate_limited = True
-            if self.run_spec.skip_evaluation or result is None:
-                # Record checkpoint with no evaluation for progress tracking
-                self.metrics_tracker.record_checkpoint_result(
-                    checkpoint.name, None
-                )
+            if (
+                self.run_spec.skip_evaluation
+                or self.run_spec.concurrent_evaluation
+                or result is None
+            ):
+                # Skip inline evaluation. For concurrent_evaluation a background
+                # thread evaluates the snapshot concurrently with the next
+                # solve (see _run_problem / _eval_one); record None now for
+                # progress and let the eval thread overwrite it.
+                with self._metrics_lock:
+                    self.metrics_tracker.record_checkpoint_result(
+                        checkpoint.name, None
+                    )
                 return AgentCheckpointSummary.from_results(
                     checkpoint_name=checkpoint.name,
                     path=checkpoint_save_dir,
@@ -918,6 +932,70 @@ class AgentRunner:
             evaluation_result=evaluation_result,
         )
 
+    def _eval_one(
+        self,
+        checkpoint: CheckpointConfig,
+        summary: AgentCheckpointSummary,
+    ) -> None:
+        """Evaluate one solved snapshot (concurrent mode; runs in a thread).
+
+        Spawns its own eval container; the snapshot is an immutable per-
+        checkpoint copy, so this is safe to run concurrently with the next
+        checkpoint's solve. At most one of these runs at a time (the caller
+        joins the previous one first), so solve stays <=1 checkpoint ahead of
+        eval and in-flight containers are bounded to 2 (this eval + 1 solve).
+        """
+        try:
+            report, _ = evaluate_agent_snapshot(
+                checkpoint=checkpoint,
+                save_dir=summary.path,
+                snapshot_dir=summary.snapshot_dir,
+                problem=self.run_spec.problem,
+                environment=self.run_spec.environment,
+            )
+        except Exception:  # noqa: BLE001
+            logger.error(
+                "Concurrent evaluation failed",
+                checkpoint=checkpoint.name,
+                exc_info=True,
+            )
+            return
+        with self._metrics_lock:
+            self._eval_reports[checkpoint.name] = report
+            self.metrics_tracker.record_checkpoint_result(
+                checkpoint.name, report
+            )
+
+    def _merge_eval_reports(
+        self, results: list[AgentCheckpointSummary]
+    ) -> list[AgentCheckpointSummary]:
+        """Fold concurrent eval reports back into the checkpoint summaries.
+
+        Call after the background eval thread has been joined. Summaries with
+        no report (errored solve, or eval that failed) are left as-is.
+        """
+        if not self.run_spec.concurrent_evaluation:
+            return results
+        merged: list[AgentCheckpointSummary] = []
+        for summary in results:
+            report = self._eval_reports.get(summary.checkpoint_name)
+            if report is None:
+                merged.append(summary)
+                continue
+            merged.append(
+                AgentCheckpointSummary.from_results(
+                    checkpoint_name=summary.checkpoint_name,
+                    path=summary.path,
+                    snapshot_dir=summary.snapshot_dir,
+                    artifacts=summary.artifacts,
+                    usage=summary.usage,
+                    had_error=summary.had_error,
+                    pass_policy=self.run_spec.pass_policy,
+                    evaluation_result=report,
+                )
+            )
+        return merged
+
     def _run_problem(self) -> list[AgentCheckpointSummary]:
         """Iterate through checkpoints, skipping completed ones if resuming."""
         # Determine checkpoints to skip when resuming
@@ -933,6 +1011,10 @@ class AgentRunner:
         )
 
         results = []
+        # Concurrent mode: a single rolling background eval thread. The previous
+        # one is joined before the next starts, so solve stays <=1 checkpoint
+        # ahead of eval and at most 2 containers (1 solve + 1 eval) run at once.
+        pending_eval: threading.Thread | None = None
         for idx, (checkpoint, checkpoint_save_dir) in enumerate(
             get_checkpoints(self.run_spec.problem, self.output_path)
         ):
@@ -986,9 +1068,35 @@ class AgentRunner:
                 checkpoint_name=summary.checkpoint_name,
             )
 
+            # Concurrent mode: evaluate this checkpoint in the background while
+            # the next one solves. Join the previous eval first (backpressure:
+            # solve stays <=1 ahead, bounding in-flight containers to 2).
+            if (
+                self.run_spec.concurrent_evaluation
+                and not summary.had_error
+                and summary.snapshot_dir is not None
+            ):
+                if pending_eval is not None:
+                    pending_eval.join()
+                pending_eval = threading.Thread(
+                    target=self._eval_one,
+                    args=(checkpoint, summary),
+                    name=f"eval-{checkpoint.name}",
+                    daemon=True,
+                )
+                pending_eval.start()
+
             # Check for early termination
             if self._should_early_stop(summary):
-                return results
+                if pending_eval is not None:
+                    pending_eval.join()
+                return self._merge_eval_reports(results)
+
+        # Concurrent eval: wait for the final background eval, then fold all
+        # reports into the summaries (no-op when concurrent eval is off).
+        if pending_eval is not None:
+            pending_eval.join()
+        results = self._merge_eval_reports(results)
 
         logger.info(
             "All checkpoints completed successfully",

--- a/src/slop_code/entrypoints/commands/run_agent.py
+++ b/src/slop_code/entrypoints/commands/run_agent.py
@@ -884,6 +884,8 @@ def _create_task_config(
     live_progress: bool,
     image_name: str,
     resume: bool,
+    *,
+    concurrent_evaluation: bool = False,
 ) -> problem_runner.RunTaskConfig:
     """Create task configuration for problem execution.
 
@@ -921,6 +923,7 @@ def _create_task_config(
         verbosity=verbosity,
         debug=debug,
         disable_evaluation=not evaluate,
+        concurrent_evaluation=concurrent_evaluation,
         live_progress=live_progress,
         image=image_name,
         resume=resume,
@@ -1115,6 +1118,14 @@ def run_agent(
         True,  # noqa: FBT003
         "--evaluate/--no-evaluate",
         help="Whether to run evaluation",
+    ),
+    concurrent_evaluation: bool = typer.Option(  # noqa: FBT001, FBT002
+        False,  # noqa: FBT003
+        "--concurrent-evaluation/--no-concurrent-evaluation",
+        help="Evaluate each checkpoint concurrently with the next "
+        "checkpoint's solve (at most one solve + one eval at a time) so eval "
+        "doesn't block progress. Scores unchanged for the ANY_CASE pass "
+        "policy; cannot early-stop on test failures.",
     ),
     live_progress: bool = typer.Option(  # noqa: FBT001, FBT002
         True,  # noqa: FBT003
@@ -1406,6 +1417,7 @@ def run_agent(
         verbosity=ctx.obj.verbosity,
         debug=ctx.obj.debug,
         evaluate=evaluate,
+        concurrent_evaluation=concurrent_evaluation,
         live_progress=live_progress,
         image_name=image_name,
         resume=is_resuming,

--- a/src/slop_code/entrypoints/problem_runner/models.py
+++ b/src/slop_code/entrypoints/problem_runner/models.py
@@ -84,6 +84,7 @@ class RunTaskConfig:
     debug: bool = False
     live_progress: bool = False
     disable_evaluation: bool = False
+    concurrent_evaluation: bool = False
     resume: bool = False
     dry_run: bool = False
     one_shot: OneShotConfig = field(default_factory=OneShotConfig)

--- a/src/slop_code/entrypoints/problem_runner/worker.py
+++ b/src/slop_code/entrypoints/problem_runner/worker.py
@@ -175,6 +175,7 @@ def run_agent_on_problem(
         environment=config.env_spec,
         pass_policy=config.pass_policy,
         skip_evaluation=config.disable_evaluation,
+        concurrent_evaluation=config.concurrent_evaluation,
         verbose=config.verbosity > 0,
         image=config.image,
         agent_type=config.agent_config.type,

--- a/tests/agent_runner/test_runner_unit.py
+++ b/tests/agent_runner/test_runner_unit.py
@@ -22,6 +22,7 @@ from slop_code.agent_runner.resume import ResumeInfo
 from slop_code.common import INFERENCE_RESULT_FILENAME
 from slop_code.common import PROMPT_FILENAME
 from slop_code.common.llms import TokenUsage
+from slop_code.evaluation.report import PassPolicy
 
 
 class StubCheckpoint:
@@ -715,3 +716,122 @@ def test_run_problem_concurrent_eval_bounds_inflight(tmp_path):
     # Reports folded back; one summary per checkpoint.
     assert len(results) == 4
     assert all(n in ar._eval_reports for n in names)
+
+
+def test_run_problem_concurrent_eval_records_failure_and_continues(
+    tmp_path: Path,
+) -> None:
+    """Concurrent eval that raises must record into `_failed_evals`, warn at
+    the next cp boundary + at end-of-run, and let subsequent cps proceed.
+    """
+    agent = Mock(spec=Agent)
+    agent.usage = _usage()
+
+    run_spec = Mock()
+    run_spec.problem = Mock()
+    run_spec.problem.name = "prob"
+    run_spec.problem.checkpoints = {
+        "checkpoint_1": Mock(),
+        "checkpoint_2": Mock(),
+        "checkpoint_3": Mock(),
+    }
+    run_spec.skip_evaluation = False
+    run_spec.concurrent_evaluation = True
+    # Use a real PassPolicy so _merge_eval_reports can rebuild summaries via
+    # AgentCheckpointSummary.from_results (which validates with pydantic).
+    run_spec.pass_policy = PassPolicy.ANY_CASE
+
+    ar = runner.AgentRunner(
+        run_spec=run_spec,
+        agent=agent,
+        output_path=tmp_path,
+        progress_queue=queue.Queue(),
+        resume_info=None,
+    )
+
+    checkpoints = [
+        (StubCheckpoint(f"checkpoint_{i}", ""), tmp_path / f"checkpoint_{i}")
+        for i in (1, 2, 3)
+    ]
+
+    def make_summary(cp_name: str) -> Mock:
+        s = Mock()
+        s.passed_policy = True  # so _should_early_stop doesn't fire
+        s.had_error = False
+        s.checkpoint_name = cp_name
+        s.snapshot_dir = tmp_path / f"{cp_name}_snap"  # truthy => eval queued
+        s.path = tmp_path / cp_name
+        s.artifacts = []
+        s.usage = _usage()
+        return s
+
+    summaries = {f"checkpoint_{i}": make_summary(f"checkpoint_{i}") for i in (1, 2, 3)}
+    eval_calls: list[str] = []
+
+    def make_report() -> Mock:
+        """Minimal mock report that record_checkpoint_result can sum over."""
+        r = Mock()
+        r.pass_counts = {"Core": 1}
+        r.total_counts = {"Core": 1}
+        return r
+
+    def eval_snapshot_side_effect(*, checkpoint, **_kwargs):
+        eval_calls.append(checkpoint.name)
+        if checkpoint.name == "checkpoint_1":
+            raise RuntimeError("boom: simulated eval failure")
+        return (make_report(), Mock())
+
+    with (
+        patch(
+            "slop_code.agent_runner.runner.get_checkpoints",
+            return_value=iter(checkpoints),
+        ),
+        patch.object(
+            runner.AgentRunner,
+            "_run_checkpoint",
+            side_effect=lambda ckpt, *_a, **_kw: summaries[ckpt.name],
+        ),
+        patch(
+            "slop_code.agent_runner.runner.evaluate_agent_snapshot",
+            side_effect=eval_snapshot_side_effect,
+        ),
+        # Bypass _merge_eval_reports — it rebuilds pydantic-validated
+        # summaries which is orthogonal to what we're testing.
+        patch.object(
+            runner.AgentRunner,
+            "_merge_eval_reports",
+            side_effect=lambda r: r,
+        ),
+        patch.object(runner.logger, "warning") as mock_warning,
+    ):
+        ar._run_problem()
+
+    # 1. cp1's failure is recorded with the exception text; cp2/cp3 are not.
+    assert "checkpoint_1" in ar._failed_evals
+    assert "boom" in ar._failed_evals["checkpoint_1"]
+    assert "checkpoint_2" not in ar._failed_evals
+    assert "checkpoint_3" not in ar._failed_evals
+
+    # 2. Subsequent cps still ran — all 3 evals were attempted in order.
+    assert eval_calls == ["checkpoint_1", "checkpoint_2", "checkpoint_3"]
+
+    # 3. Boundary warning fired exactly once for cp1 (at cp2's boundary).
+    boundary_warnings = [
+        call for call in mock_warning.call_args_list
+        if call.args
+        and "Concurrent eval failed for earlier checkpoint" in call.args[0]
+        and call.kwargs.get("checkpoint") == "checkpoint_1"
+    ]
+    assert len(boundary_warnings) == 1, (
+        f"expected 1 boundary warning for cp1, got "
+        f"{len(boundary_warnings)}: {boundary_warnings}"
+    )
+
+    # 4. End-of-run summary warning lists cp1 as a failed eval.
+    summary_warnings = [
+        call for call in mock_warning.call_args_list
+        if call.args and "Run completed with concurrent eval failures" in call.args[0]
+    ]
+    assert len(summary_warnings) == 1
+    assert summary_warnings[0].kwargs.get("failed_checkpoints") == ["checkpoint_1"]
+    assert summary_warnings[0].kwargs.get("count") == 1

--- a/tests/agent_runner/test_runner_unit.py
+++ b/tests/agent_runner/test_runner_unit.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 import queue
+import threading
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from unittest.mock import Mock
@@ -404,6 +406,7 @@ def test_run_problem_resume_does_not_treat_first_executed_as_checkpoint_1(
         "checkpoint_3": Mock(),
     }
     run_spec.skip_evaluation = True
+    run_spec.concurrent_evaluation = False
     run_spec.pass_policy = Mock()
 
     resume_info = ResumeInfo(
@@ -479,6 +482,7 @@ def test_run_problem_resume_does_not_double_count_prior_usage(
         "checkpoint_3": Mock(),
     }
     run_spec.skip_evaluation = True
+    run_spec.concurrent_evaluation = False
     run_spec.pass_policy = Mock()
 
     resume_info = ResumeInfo(
@@ -554,6 +558,7 @@ def test_run_problem_resume_does_not_duplicate_preloaded_checkpoint_results(
     }
     run_spec.compress_artifacts = False
     run_spec.skip_evaluation = True
+    run_spec.concurrent_evaluation = False
     run_spec.pass_policy = Mock()
 
     resume_info = ResumeInfo(
@@ -618,3 +623,95 @@ def test_run_problem_resume_does_not_duplicate_preloaded_checkpoint_results(
         "checkpoint_2",
         "checkpoint_3",
     ]
+
+
+def test_run_problem_concurrent_eval_bounds_inflight(tmp_path):
+    """Concurrent eval runs in a rolling background thread.
+
+    Verifies: every checkpoint is evaluated, AT MOST ONE eval is in flight at
+    a time (so in-flight containers stay bounded to 1 solve + 1 eval), reports
+    are merged back into the summaries, and the run does not deadlock.
+    """
+    agent = Mock(spec=Agent)
+    agent.usage = _usage()
+
+    run_spec = Mock()
+    run_spec.problem = Mock()
+    run_spec.problem.name = "prob"
+    run_spec.problem.checkpoints = {
+        f"checkpoint_{i}": Mock() for i in range(1, 5)
+    }
+    run_spec.skip_evaluation = False
+    run_spec.concurrent_evaluation = True
+    run_spec.environment = Mock()
+    run_spec.pass_policy = Mock()
+    run_spec.pass_policy.check.return_value = True
+
+    ar = runner.AgentRunner(
+        run_spec=run_spec,
+        agent=agent,
+        output_path=tmp_path,
+        progress_queue=queue.Queue(),
+    )
+
+    names = [f"checkpoint_{i}" for i in range(1, 5)]
+    checkpoints = [(StubCheckpoint(n, ""), tmp_path / n) for n in names]
+
+    def make_summary(name: str) -> Mock:
+        s = Mock()
+        s.checkpoint_name = name
+        s.had_error = False
+        s.passed_policy = None
+        s.snapshot_dir = tmp_path / name / "snapshot"
+        s.path = tmp_path / name
+        s.artifacts = tmp_path / name / "artifacts"
+        s.usage = _usage()
+        return s
+
+    solved: list[str] = []
+
+    def fake_run_checkpoint(checkpoint, save_dir, is_first):  # noqa: ANN001
+        solved.append(checkpoint.name)
+        time.sleep(0.02)  # let an eval overlap the next solve
+        return make_summary(checkpoint.name)
+
+    inflight = {"cur": 0, "max": 0}
+    lock = threading.Lock()
+    evaluated: list[str] = []
+
+    def fake_eval(*, checkpoint, save_dir, snapshot_dir, problem, environment):  # noqa: ANN001
+        with lock:
+            inflight["cur"] += 1
+            inflight["max"] = max(inflight["max"], inflight["cur"])
+        time.sleep(0.05)
+        with lock:
+            inflight["cur"] -= 1
+            evaluated.append(checkpoint.name)
+        return (Mock(), None)
+
+    with (
+        patch(
+            "slop_code.agent_runner.runner.get_checkpoints",
+            return_value=iter(checkpoints),
+        ),
+        patch.object(
+            runner.AgentRunner,
+            "_run_checkpoint",
+            side_effect=fake_run_checkpoint,
+        ),
+        patch(
+            "slop_code.agent_runner.runner.evaluate_agent_snapshot",
+            side_effect=fake_eval,
+        ),
+        patch.object(runner.MetricsTracker, "record_checkpoint_result"),
+        patch.object(runner.MetricsTracker, "finish_checkpoint"),
+    ):
+        results = ar._run_problem()
+
+    assert solved == names
+    assert sorted(evaluated) == sorted(names)
+    # The core guarantee: never more than one eval running at once.
+    assert inflight["max"] == 1
+    # Reports folded back; one summary per checkpoint.
+    assert len(results) == 4
+    assert all(n in ar._eval_reports for n in names)


### PR DESCRIPTION
Currently, evaluation runs serially between checkpoints - a checkpoint's tests must finish before the agent starts the next one even though eval results never feed back into the (blind) agent. This adds an opt-in --concurrent-evaluation flag that instead runs each checkpoint's eval concurrently with the next checkpoint's solve, so eval no longer blocks progress. On subprocess/compile-heavy problems (such as test_translator), evaluation is ~57% of per-run wall-clock so this approximately halves the run-time.

A single rolling background thread evaluates checkpoint N while N+1 solves; the previous eval is joined before the next starts, so solve stays <= 1 checkpoint ahead of eval and at most one solve + one eval run at a time (in-flight containers bounded to 2). Results land per-checkpoint as each eval completes, not batched at the end. Off by default.

Since eval never feeds the agent, scores are unchanged for the ANY_CASE pass policy, verified by re-evaluating recorded snapshots: pass counts and test_collection_hash bit-for-bit identical at checkpoints.

Trade-off: can't early-stop on test failures (a checkpoint's eval finishes during the next solve); agent errors and rate limits will stop the run.