### PR TITLE
Isolate eval pytest collection from agent-authored conftest.py

### DIFF
--- a/src/slop_code/evaluation/collection.py
+++ b/src/slop_code/evaluation/collection.py
@@ -171,6 +171,9 @@ def _build_collect_cmd(
         "pytest",
         "--collect-only",
         "-q",
+        # Exclude an agent-authored conftest.py at the workspace root from
+        # collection (SCBench's own conftest lives inside WORKSPACE_TEST_DIR).
+        f"--confcutdir={WORKSPACE_TEST_DIR}",
         f"--entrypoint={shlex.quote(entrypoint)}",
         f"--checkpoint={shlex.quote(checkpoint_name)}",
     ]

--- a/src/slop_code/evaluation/pytest_runner.py
+++ b/src/slop_code/evaluation/pytest_runner.py
@@ -301,6 +301,10 @@ markers =
             *self._build_pytest_base_parts(),
             *timeout_args,
             *self._build_common_pytest_args(),
+            # Limit conftest discovery to the eval test dir so an agent-authored
+            # conftest.py at the workspace root can't break collection (SCBench's
+            # own conftest lives inside WORKSPACE_TEST_DIR and still loads).
+            f"--confcutdir={WORKSPACE_TEST_DIR}",
             f"--ctrf={CTRF_REPORT_REL_PATH}",
             "--json-report",
             f"--json-report-file={PYTEST_REPORT_REL_PATH}",

--- a/tests/evaluation/collection_test.py
+++ b/tests/evaluation/collection_test.py
@@ -1,12 +1,33 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 from slop_code import evaluation
+from slop_code.common import WORKSPACE_TEST_DIR
+from slop_code.evaluation.collection import _build_collect_cmd
 from slop_code.evaluation.collection import compute_tc_hash
 
 
 def test_public_collection_functions_exported() -> None:
     assert callable(evaluation.collect_checkpoint_tc)
     assert callable(evaluation.compute_tc_hash)
+
+
+def test_collect_cmd_excludes_agent_conftest() -> None:
+    """The --collect-only passes must exclude an agent-authored root conftest.py.
+
+    Pytest otherwise loads a conftest.py at the workspace root (an ancestor of
+    the eval test dir); if it errors or conflicts, collection aborts (exit 4)
+    and the checkpoint scores 0 as an infrastructure failure.
+    """
+    cmd = _build_collect_cmd(
+        problem=SimpleNamespace(test_dependencies=[]),
+        checkpoint_name="checkpoint_1",
+        entrypoint="python main.py",
+        marker="functionality",
+        pytest_args=None,
+    )
+    assert f"--confcutdir={WORKSPACE_TEST_DIR}" in cmd
 
 
 def test_compute_tc_hash_stable_for_reordered_input() -> None:

--- a/tests/evaluation/pytest_runner_test.py
+++ b/tests/evaluation/pytest_runner_test.py
@@ -285,6 +285,9 @@ class TestPytestRunner:
         assert "checkpoint_2" in cmd
         # Static assets are now passed via env vars, not CLI
         assert "--static-assets" not in cmd
+        # confcutdir keeps an agent-authored conftest.py at the workspace root
+        # from being loaded during collection (which would abort the run).
+        assert "--confcutdir=.evaluation_tests" in cmd
         assert "--ctrf=.scbench/ctrf-report.json" in cmd
         assert "--json-report" in cmd
         assert "--json-report-file=.scbench/pytest-report.json" in cmd


### PR DESCRIPTION
Fixes #15

An agent that writes its own test scaffolding (a conftest.py / test_*.py) at the workspace root silently zeroes its checkpoint: the evaluation copies SCBench's tests into the workspace and runs pytest, which loads the agent's root conftest.py as a rootdir ancestor. If it errors or conflicts, collection aborts (exit 4, 0 collected) before any SCBench test runs -> the checkpoint is recorded as an infrastructure failure / 0%, even though the solution is fine.

This perversely penalizes agents that write tests (good practice), on any model. Repro: Claude Code + the SuperPowers skill on trajectory_api wrote a root conftest.py and scored 0/0/0/0/0; re-evaluating the same snapshots with this fix yields 86/71/89/33/0.

Fix: pass --confcutdir=<WORKSPACE_TEST_DIR> on both pytest paths — the main test run (pytest_runner.py) and the per-marker --collect-only passes (collection.py). This caps conftest discovery at the eval test dir, so an agent's workspace-root conftest.py is never loaded while SCBench's own conftest (inside WORKSPACE_TEST_DIR) still is. Adds regression tests on both commands.